### PR TITLE
Fix Check Release job on CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ try:
         get_data_files
     )
     post_develop = npm_builder(
-        build_cmd="install:extension", source_dir="src", build_dir=lab_path
+        build_cmd="build:prod", source_dir="src", build_dir=lab_path
     )
     setup_args["cmdclass"] = wrap_installers(post_develop=post_develop, ensured_targets=ensured_targets)
     setup_args["data_files"] = get_data_files(data_files_spec)


### PR DESCRIPTION
The check release check on CI is useful as it continuously gives a good indication whether the package can be released to PyPI.

We should make it pass to give more confidence we can release the package.