### PR TITLE
using kernel agnostic names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ RUN cd /opt/xwidgets/build && \
 
 RUN mkdir -p /opt/xeus-lua/
 RUN git clone -b main    https://github.com/DerThorsten/xeus-lua.git   /opt/xeus-lua
-RUN cd /opt/xeus-lua && git checkout tags/0.5.9
+RUN cd /opt/xeus-lua && git checkout tags/0.5.10
 # COPY xeus-lua /opt/xeus-lua
 
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:dockerimage": "docker build -t mydockerimage  --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) . ",
     "build:dockerimage_no_cache": "docker build -t mydockerimage  --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --no-cache . ",
     "build:emscripten": "echo $(pwd) && docker run --rm -v $(pwd):/src    -u $(id -u):$(id -g)  mydockerimage    ./build.sh",
-    "copy-files": "copyfiles -u 1 src/xeus_lua.wasm  src/xeus_lua.worker.js src/xeus_lua.js lib",
+    "copy-files": "copyfiles -u 1 src/xeus_kernel.wasm  src/xeus_kernel.worker.js src/xeus_kernel.js lib",
     "build:wasm": "jlpm run build:dockerimage && jlpm run build:emscripten",
     "build:wasm_no_cache": "jlpm run build:dockerimage_no_cache && jlpm run build:emscripten",
     "build": "jlpm run build:lib && jlpm run copy-files && jlpm run build:labextension:dev",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import createXeusModule from './xeus_lua.js';
+import createXeusModule from './xeus_kernel.js';
 
 // We alias self to ctx and give it our newly created type
 const ctx: Worker = self as any;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ module.exports = {
     new CopyPlugin({
       patterns: [
         {
-          from: 'src/xeus_lua.wasm',
+          from: 'src/xeus_kernel.wasm',
           to: '.'
         }
       ]


### PR DESCRIPTION
using `xeus_kernel.{js/wasm}` instead of `xeus_lua.{js,wasm}` to make it easier to write the common code shared by multiple xeus kernels